### PR TITLE
refactor: :lipstick: atualiza nomes de variáveis e funções para pt-br

### DIFF
--- a/caju.postman_collection.json
+++ b/caju.postman_collection.json
@@ -73,7 +73,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\r\n\t\"account\": \"789012\",\r\n\t\"amount\": 100.00,\r\n\t\"mcc\": \"5811\",\r\n\t\"merchant\": \"Restaurante A\"\r\n}",
+					"raw": "{\r\n\t\"conta\": \"789012\",\r\n\t\"valor\": 100.00,\r\n\t\"mcc\": \"5811\",\r\n\t\"estabelecimento\": \"Restaurante A\"\r\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -115,7 +115,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\r\n\t\"account\": \"789012\",\r\n\t\"amount\": 100.00,\r\n\t\"mcc\": \"5812\",\r\n\t\"merchant\": \"Restaurante B\"\r\n}",
+					"raw": "{\r\n\t\"conta\": \"789012\",\r\n\t\"valor\": 100.00,\r\n\t\"mcc\": \"5812\",\r\n\t\"estabelecimento\": \"Restaurante B\"\r\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -157,7 +157,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\r\n\t\"account\": \"123456\",\r\n\t\"amount\": 100.00,\r\n\t\"mcc\": \"5411\",\r\n\t\"merchant\": \"Supermercado A\"\r\n}",
+					"raw": "{\r\n\t\"conta\": \"123456\",\r\n\t\"valor\": 100.00,\r\n\t\"mcc\": \"5411\",\r\n\t\"estabelecimento\": \"Supermercado A\"\r\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -199,7 +199,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\r\n\t\"account\": \"123456\",\r\n\t\"amount\": 100.00,\r\n\t\"mcc\": \"5412\",\r\n\t\"merchant\": \"Supermercado B\"\r\n}",
+					"raw": "{\r\n\t\"conta\": \"123456\",\r\n\t\"valor\": 100.00,\r\n\t\"mcc\": \"5412\",\r\n\t\"estabelecimento\": \"Supermercado B\"\r\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -241,7 +241,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\r\n\t\"account\": \"789012\",\r\n\t\"amount\": 2800.01, //a carteira meal nesse momento tinha 2800 e a cash 3000, após ficou 199.99\r\n\t\"mcc\": \"5811\",\r\n\t\"merchant\": \"Supermercado B\"\r\n}",
+					"raw": "{\r\n\t\"conta\": \"789012\",\r\n\t\"valor\": 2800.01, //a carteira meal nesse momento tinha 2800 e a cash 3000, após ficou 199.99\r\n\t\"mcc\": \"5811\",\r\n\t\"estabelecimento\": \"Supermercado B\"\r\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -283,7 +283,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\r\n\t\"account\": \"789012\",\r\n\t\"amount\": 100, //descontou da carteira cash porque não achou o mcc e nem o merchant\r\n\t\"mcc\": \"58191\",\r\n\t\"merchant\": \"Loja jp\"\r\n}",
+					"raw": "{\r\n\t\"conta\": \"789012\",\r\n\t\"valor\": 100, //descontou da carteira cash porque não achou o mcc e nem o estabelecimento\r\n\t\"mcc\": \"58191\",\r\n\t\"estabelecimento\": \"Loja jp\"\r\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -313,7 +313,7 @@
 			"response": []
 		},
 		{
-			"name": "Efetivar Transação - Mapear por merchant",
+			"name": "Efetivar Transação - Mapear por estabelecimento",
 			"request": {
 				"method": "POST",
 				"header": [
@@ -325,7 +325,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\r\n\t\"account\": \"789012\",\r\n\t\"amount\": 0.55,\r\n\t\"mcc\": \"581911\",\r\n\t\"merchant\": \"Restaurante A\"\r\n}",
+					"raw": "{\r\n\t\"conta\": \"789012\",\r\n\t\"valor\": 0.55,\r\n\t\"mcc\": \"581911\",\r\n\t\"estabelecimento\": \"Restaurante A\"\r\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -367,7 +367,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\r\n\t\"account\": \"789012\",\r\n\t\"amount\": 2900,\r\n\t\"mcc\": \"581911\",\r\n\t\"merchant\": \"Restaurante A\"\r\n}",
+					"raw": "{\r\n\t\"conta\": \"789012\",\r\n\t\"valor\": 2900,\r\n\t\"mcc\": \"581911\",\r\n\t\"estabelecimento\": \"Restaurante A\"\r\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -409,7 +409,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\r\n\t\"account\": \"78901200\", //conta não existente\r\n\t\"amount\": 2900,\r\n\t\"mcc\": \"581911\",\r\n\t\"merchant\": \"Restaurante A\"\r\n}",
+					"raw": "{\r\n\t\"conta\": \"78901200\", //conta não existente\r\n\t\"valor\": 2900,\r\n\t\"mcc\": \"581911\",\r\n\t\"estabelecimento\": \"Restaurante A\"\r\n}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/lib/caju/guardian.ex
+++ b/lib/caju/guardian.ex
@@ -7,8 +7,8 @@ defmodule Caju.Guardian do
   end
 
   def resource_from_claims(%{"sub" => uuid}) do
-    case EstabelecimentosService.get_estabelecimento_uuid(uuid) do
-      nil -> {:error, :resource_not_found}
+    case EstabelecimentosService.pegar_estabelecimento_por_uuid(uuid) do
+      :no_content -> {:error, :resource_not_found}
       estabelecimento -> {:ok, estabelecimento}
     end
   end

--- a/lib/caju/repositories/contas_repository.ex
+++ b/lib/caju/repositories/contas_repository.ex
@@ -2,11 +2,11 @@ defmodule Caju.Repositories.ContasRepository do
   alias Caju.Repo
   alias Caju.Contas
 
-  def pegar_conta_by_id(id) do
+  def pegar_conta_por_id(id) do
     Repo.get(Contas, id)
   end
 
-  def pegar_conta_by_numero(numero) do
+  def pegar_conta_por_numero(numero) do
     Repo.get_by(Contas, numero_conta: numero)
   end
 end

--- a/lib/caju/repositories/estabelecimentos_repository.ex
+++ b/lib/caju/repositories/estabelecimentos_repository.ex
@@ -2,7 +2,7 @@ defmodule Caju.Repositories.EstabelecimentosRepository do
   import Ecto.Query, warn: false
   alias Caju.{Estabelecimentos, Repo}
 
-  def get_estabelecimento_uuid(uuid) do
+  def pegar_estabelecimento_por_uuid(uuid) do
     Estabelecimentos
     |> where([e], e.uuid == ^uuid)
     |> Repo.one()

--- a/lib/caju/repositories/mccs_repository.ex
+++ b/lib/caju/repositories/mccs_repository.ex
@@ -3,14 +3,14 @@ defmodule Caju.Repositories.MccsRepository do
   alias Caju.Repo
   alias Caju.Mccs
 
-  def pegar_mcc_by_codigo(codigo) do
+  def pegar_mcc_por_codigo(codigo) do
     Repo.get_by(Mccs, codigo_mcc: codigo)
   end
 
-  def pegar_mcc_merchant(merchant) do
+  def pegar_mcc_estabelecimento(estabelecimento) do
     query =
       from m in Mccs,
-        where: like(m.nome_estabelecimento, ^"%#{merchant}%")
+        where: like(m.nome_estabelecimento, ^"%#{estabelecimento}%")
 
     Repo.all(query)
   end

--- a/lib/caju/repositories/transacoes_repository.ex
+++ b/lib/caju/repositories/transacoes_repository.ex
@@ -2,13 +2,13 @@ defmodule Caju.Repositories.TransacoesRepository do
   import Ecto.Query, warn: false
   alias Caju.{Repo, TransacoesCash, TransacoesFood, TransacoesMeal}
 
-  def lancar_transacoes_cash(carteira, tipo, status, amount) do
-    amount_decimal = Decimal.new(to_string(amount))
+  def lancar_transacoes_cash(carteira, tipo, status, valor) do
+    valor_decimal = Decimal.new(to_string(valor))
 
     transacao = %TransacoesCash{
       conta_id: carteira.conta_id,
       tipo: tipo,
-      valor: amount_decimal,
+      valor: valor_decimal,
       status: status,
       criado_em: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
     }
@@ -22,13 +22,13 @@ defmodule Caju.Repositories.TransacoesRepository do
     end
   end
 
-  def lancar_transacoes_food(carteira, tipo, status, amount) do
-    amount_decimal = Decimal.new(to_string(amount))
+  def lancar_transacoes_food(carteira, tipo, status, valor) do
+    valor_decimal = Decimal.new(to_string(valor))
 
     transacao = %TransacoesFood{
       conta_id: carteira.conta_id,
       tipo: tipo,
-      valor: amount_decimal,
+      valor: valor_decimal,
       status: status,
       criado_em: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
     }
@@ -42,13 +42,13 @@ defmodule Caju.Repositories.TransacoesRepository do
     end
   end
 
-  def lancar_transacoes_meal(carteira, tipo, status, amount) do
-    amount_decimal = Decimal.new(to_string(amount))
+  def lancar_transacoes_meal(carteira, tipo, status, valor) do
+    valor_decimal = Decimal.new(to_string(valor))
 
     transacao = %TransacoesMeal{
       conta_id: carteira.conta_id,
       tipo: tipo,
-      valor: amount_decimal,
+      valor: valor_decimal,
       status: status,
       criado_em: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
     }

--- a/lib/caju/services/carteiras_service.ex
+++ b/lib/caju/services/carteiras_service.ex
@@ -5,10 +5,10 @@ defmodule Caju.Services.CarteirasService do
     defstruct [:id, :saldo, :conta]
   end
 
-  def get_carteira_by_conta(conta_numero) do
-    case pegar_conta_by_numero(conta_numero) do
+  def pegar_carteira_por_conta(conta_numero) do
+    case pegar_conta_por_numero(conta_numero) do
       {:ok, conta} ->
-        carteiras = ContasCarteirasRepository.get_carteiras_by_conta_id(conta.id)
+        carteiras = ContasCarteirasRepository.buscar_carteiras_por_conta_id(conta.id)
         {:ok, carteiras}
 
       :no_content ->
@@ -16,7 +16,7 @@ defmodule Caju.Services.CarteirasService do
     end
   end
 
-  def pegar_conta_by_numero(conta_numero) do
-    ContasServices.pegar_conta_by_numero(conta_numero)
+  def pegar_conta_por_numero(conta_numero) do
+    ContasServices.pegar_conta_por_numero(conta_numero)
   end
 end

--- a/lib/caju/services/contas_services.ex
+++ b/lib/caju/services/contas_services.ex
@@ -1,8 +1,8 @@
 defmodule Caju.ContasServices do
   alias Caju.Repositories.ContasRepository
 
-  def pegar_conta_by_id(id) do
-    conta = ContasRepository.pegar_conta_by_id(id)
+  def pegar_conta_por_id(id) do
+    conta = ContasRepository.pegar_conta_por_id(id)
 
     case conta do
       nil -> :no_content
@@ -10,8 +10,8 @@ defmodule Caju.ContasServices do
     end
   end
 
-  def pegar_conta_by_numero(numero) do
-    conta = ContasRepository.pegar_conta_by_numero(numero)
+  def pegar_conta_por_numero(numero) do
+    conta = ContasRepository.pegar_conta_por_numero(numero)
 
     case conta do
       nil -> :no_content

--- a/lib/caju/services/estabelecimentos_service.ex
+++ b/lib/caju/services/estabelecimentos_service.ex
@@ -1,8 +1,8 @@
 defmodule Caju.Services.EstabelecimentosService do
   alias Caju.Repositories.EstabelecimentosRepository
 
-  def get_estabelecimento_uuid(uuid) do
-    estabelecimento = EstabelecimentosRepository.get_estabelecimento_uuid(uuid)
+  def pegar_estabelecimento_por_uuid(uuid) do
+    estabelecimento = EstabelecimentosRepository.pegar_estabelecimento_por_uuid(uuid)
 
     case estabelecimento do
       nil -> :no_content
@@ -10,8 +10,8 @@ defmodule Caju.Services.EstabelecimentosService do
     end
   end
 
-  def authenticate(uuid, senha) do
-    case EstabelecimentosRepository.get_estabelecimento_uuid(uuid) do
+  def autenticar(uuid, senha) do
+    case EstabelecimentosRepository.pegar_estabelecimento_por_uuid(uuid) do
       nil ->
         :error
 

--- a/lib/caju/services/mccs_service.ex
+++ b/lib/caju/services/mccs_service.ex
@@ -1,10 +1,10 @@
 defmodule Caju.Services.MccsService do
   alias Caju.Repositories.MccsRepository
 
-  def buscar_mccs(mcc, merchant) do
-    case MccsRepository.pegar_mcc_by_codigo(mcc) do
+  def buscar_mccs(mcc, estabelecimento) do
+    case MccsRepository.pegar_mcc_por_codigo(mcc) do
       nil ->
-        case MccsRepository.pegar_mcc_merchant(merchant) do
+        case MccsRepository.pegar_mcc_estabelecimento(estabelecimento) do
           [] -> {:error, :mcc_nao_encontrado}
           mcc -> valida_quantidade_mccs(mcc)
         end

--- a/lib/caju_web/controllers/auth_controller.ex
+++ b/lib/caju_web/controllers/auth_controller.ex
@@ -4,7 +4,7 @@ defmodule CajuWeb.AuthController do
   alias Caju.Guardian
 
   def login(conn, %{"uuid" => uuid, "senha" => senha}) do
-    case EstabelecimentosService.authenticate(uuid, senha) do
+    case EstabelecimentosService.autenticar(uuid, senha) do
       {:ok, estabelecimento} ->
         claims = %{
           "nome" => estabelecimento.nome_estabelecimento,

--- a/lib/caju_web/controllers/contas_controller.ex
+++ b/lib/caju_web/controllers/contas_controller.ex
@@ -2,8 +2,8 @@ defmodule CajuWeb.ContasController do
   use CajuWeb, :controller
   alias Caju.ContasServices
 
-  def get_conta(conn, %{"id" => id}) do
-    with {:ok, conta} <- ContasServices.pegar_conta_by_id(id) do
+  def pegar_conta(conn, %{"id" => id}) do
+    with {:ok, conta} <- ContasServices.pegar_conta_por_id(id) do
       json(conn, conta)
     else
       :error -> send_resp(conn, 404, "")

--- a/lib/caju_web/controllers/transacao_controller.ex
+++ b/lib/caju_web/controllers/transacao_controller.ex
@@ -3,15 +3,15 @@ defmodule CajuWeb.TransacaoController do
   alias Caju.Services.TransacaoService
 
   def efetivar_transacao(conn, %{
-        "account" => account,
-        "amount" => amount,
+        "conta" => conta,
+        "valor" => valor,
         "mcc" => mcc,
-        "merchant" => merchant
+        "estabelecimento" => estabelecimento
       }) do
-    case TransacaoService.buscar_carteira_por_conta(account) do
+    case TransacaoService.buscar_carteira_por_conta(conta) do
       {:ok, carteiras} ->
         code =
-          TransacaoService.efetivar_transacao(carteiras, amount, mcc, merchant)
+          TransacaoService.efetivar_transacao(carteiras, valor, mcc, estabelecimento)
           |> pegar_codigo_transacao()
 
         conn


### PR DESCRIPTION
essa correção altera o nome das funções e variáveis para pt-br seguindo o padrão inicial do projeto que começou com a maioria dos nomes em pt-br.